### PR TITLE
Feature/reajuste modulo eventos adm

### DIFF
--- a/controllers/EventosAdminController.php
+++ b/controllers/EventosAdminController.php
@@ -1,7 +1,6 @@
 <?php
 session_start();
 require_once '../models/EventosAdmin.php';
-
 header('Content-Type: application/json');
 
 class EventoController {

--- a/controllers/EventosAdminController.php
+++ b/controllers/EventosAdminController.php
@@ -23,6 +23,7 @@ class EventoController {
                 $this->get();
                 break;
             case 'crear':
+                $data['estado'] = 'DISPONIBLE'; 
                 $this->crear();
                 break;
             case 'editar':
@@ -66,13 +67,15 @@ class EventoController {
             return;
         }
         $data = $_POST;
-        $required = ['titulo', 'descripcion', 'horas', 'fechaInicio', 'fechaFin', 'modalidad', 'notaAprobacion', 'costo', 'esSoloInternos', 'esPagado', 'categoria', 'tipoEvento', 'carrera', 'estado', 'responsable', 'organizador'];
+        $required = ['titulo', 'descripcion', 'horas', 'fechaInicio', 'fechaFin', 'modalidad', 'notaAprobacion', 'esSoloInternos', 'esPagado', 'categoria', 'tipoEvento', 'carrera', 'capacidad', 'responsable', 'organizador'];
+        
         foreach ($required as $campo) {
-            if (empty($data[$campo])) {
+            if (!isset($data[$campo]) || $data[$campo] === '') {
                 $this->json(['success' => false, 'mensaje' => "El campo $campo es obligatorio"]);
                 return;
             }
         }
+
         $idEvento = $this->eventoModelo->crear($data);
         $this->json($idEvento ? ['success' => true, 'id' => $idEvento] : ['success' => false, 'mensaje' => 'No se pudo crear el evento']);
     }

--- a/models/EventosAdmin.php
+++ b/models/EventosAdmin.php
@@ -31,14 +31,15 @@ class Evento {
     }
 
     public function crear($data) {
-        $sql = "INSERT INTO evento (TITULO, DESCRIPCION, HORAS, FECHAINICIO, FECHAFIN, CODIGOMODALIDAD, NOTAAPROBACION, COSTO, ES_SOLO_INTERNOS, ES_PAGADO, SECUENCIALCATEGORIA, CODIGOTIPOEVENTO, SECUENCIALCARRERA, ESTADO)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        $sql = "INSERT INTO evento (TITULO, DESCRIPCION, HORAS, FECHAINICIO, FECHAFIN, CODIGOMODALIDAD, NOTAAPROBACION, COSTO, ES_SOLO_INTERNOS, ES_PAGADO, SECUENCIALCATEGORIA, CODIGOTIPOEVENTO, SECUENCIALCARRERA, ESTADO, CAPACIDAD)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
         $stmt = $this->pdo->prepare($sql);
         $ok = $stmt->execute([
             $data['titulo'], $data['descripcion'], $data['horas'], $data['fechaInicio'], $data['fechaFin'],
             $data['modalidad'], $data['notaAprobacion'], $data['costo'], $data['esSoloInternos'], $data['esPagado'],
-            $data['categoria'], $data['tipoEvento'], $data['carrera'], $data['estado']
+            $data['categoria'], $data['tipoEvento'], $data['carrera'], $data['estado'], $data['capacidad']
         ]);
+
         if (!$ok) return false;
         $idEvento = $this->pdo->lastInsertId();
 

--- a/public/js/eventoAdmin.js
+++ b/public/js/eventoAdmin.js
@@ -270,3 +270,4 @@ document.addEventListener('DOMContentLoaded', function () {
         $('#modalEvento').modal('show');
     });
 });
+

--- a/public/js/eventoAdmin.js
+++ b/public/js/eventoAdmin.js
@@ -1,4 +1,3 @@
-// Variables globales
 let tablaEventos;
 
 function inicializarTablaEventos() {
@@ -9,11 +8,9 @@ function inicializarTablaEventos() {
         ajax: {
             url: '../controllers/EventosAdminController.php?option=listar',
             dataSrc: function (json) {
-                // Si el checkbox está marcado, muestra solo cancelados
                 if (mostrarCancelados) {
                     return json.filter(e => e.ESTADO === 'CANCELADO');
                 }
-                // Si no, muestra solo disponibles
                 return json.filter(e => e.ESTADO === 'DISPONIBLE');
             }
         },
@@ -30,9 +27,9 @@ function inicializarTablaEventos() {
                 data: null,
                 render: function (data, type, row) {
                     return `
-                    <button onclick="editarEvento(${row.SECUENCIAL})" class="btn btn-primary btn-sm" title="Editar"><i class="fa fa-pencil"></i></button>
-                    <button onclick="eliminarEvento(${row.SECUENCIAL})" class="btn btn-danger btn-sm" title="Eliminar"><i class="fa fa-trash"></i></button>
-                    <button onclick="cancelarEvento(${row.SECUENCIAL})" class="btn btn-warning btn-sm" title="Cancelar"><i class="fa fa-ban"></i></button>
+                        <button onclick="editarEvento(${row.SECUENCIAL})" class="btn btn-primary btn-sm" title="Editar"><i class="fa fa-pencil"></i></button>
+                        <button onclick="eliminarEvento(${row.SECUENCIAL})" class="btn btn-danger btn-sm" title="Eliminar"><i class="fa fa-trash"></i></button>
+                        <button onclick="cancelarEvento(${row.SECUENCIAL})" class="btn btn-warning btn-sm" title="Cancelar"><i class="fa fa-ban"></i></button>
                     `;
                 }
             }
@@ -52,7 +49,6 @@ function cargarSelectOrganizadores() {
         });
 }
 
-// NUEVO: Cargar catálogos para los selects del formulario de evento
 function cargarSelectsEvento() {
     axios.get('../controllers/EventosAdminController.php?option=catalogos')
         .then(res => {
@@ -60,7 +56,6 @@ function cargarSelectsEvento() {
             llenarSelectGenerico('tipoEvento', res.data.tipos, 'CODIGO', 'NOMBRE');
             llenarSelectGenerico('modalidad', res.data.modalidades, 'CODIGO', 'NOMBRE');
             llenarSelectGenerico('categoria', res.data.categorias, 'SECUENCIAL', 'NOMBRE');
-            llenarSelectGenerico('estado', res.data.estados, 'value', 'text');
         });
 }
 
@@ -76,7 +71,6 @@ function llenarSelect(id, opciones) {
     });
 }
 
-// Para catálogos con campos personalizados
 function llenarSelectGenerico(id, opciones, valueField, textField) {
     const select = document.getElementById(id);
     if (!select) return;
@@ -93,40 +87,41 @@ function editarEvento(id) {
     axios.get(`../controllers/EventosAdminController.php?option=get&id=${id}`)
         .then(res => {
             const e = res.data;
-            if (document.getElementById('idEvento')) document.getElementById('idEvento').value = e.SECUENCIAL;
-            if (document.getElementById('titulo')) document.getElementById('titulo').value = e.TITULO;
-            if (document.getElementById('descripcion')) document.getElementById('descripcion').value = e.DESCRIPCION;
-            if (document.getElementById('horas')) document.getElementById('horas').value = e.HORAS;
-            if (document.getElementById('fechaInicio')) document.getElementById('fechaInicio').value = e.FECHAINICIO;
-            if (document.getElementById('fechaFin')) document.getElementById('fechaFin').value = e.FECHAFIN;
-            if (document.getElementById('modalidad')) document.getElementById('modalidad').value = e.CODIGOMODALIDAD;
-            if (document.getElementById('tipoEvento')) document.getElementById('tipoEvento').value = e.CODIGOTIPOEVENTO;
-            if (document.getElementById('carrera')) document.getElementById('carrera').value = e.SECUENCIALCARRERA;
-            if (document.getElementById('categoria')) document.getElementById('categoria').value = e.SECUENCIALCATEGORIA;
-            if (document.getElementById('notaAprobacion')) document.getElementById('notaAprobacion').value = e.NOTAAPROBACION;
-            if (document.getElementById('costo')) document.getElementById('costo').value = e.COSTO;
-            // esSoloInternos: select o checkbox
-            if (document.getElementById('publicoDestino')) {
-                document.getElementById('publicoDestino').value = e.ES_SOLO_INTERNOS == 1 ? 'internos' : 'externos';
+            document.getElementById('idEvento').value = e.SECUENCIAL;
+            document.getElementById('titulo').value = e.TITULO;
+            document.getElementById('descripcion').value = e.DESCRIPCION;
+            document.getElementById('horas').value = e.HORAS;
+            document.getElementById('fechaInicio').value = e.FECHAINICIO;
+            document.getElementById('fechaFin').value = e.FECHAFIN;
+            document.getElementById('modalidad').value = e.CODIGOMODALIDAD;
+            document.getElementById('tipoEvento').value = e.CODIGOTIPOEVENTO;
+            document.getElementById('carrera').value = e.SECUENCIALCARRERA;
+            document.getElementById('categoria').value = e.SECUENCIALCATEGORIA;
+            document.getElementById('notaAprobacion').value = e.NOTAAPROBACION;
+            document.getElementById('costo').value = e.COSTO;
+            document.getElementById('capacidad').value = e.CAPACIDAD;
+            document.getElementById('esSoloInternos').value = e.ES_SOLO_INTERNOS;
+            document.getElementById('esPagado').checked = e.ES_PAGADO == 1;
+            document.getElementById('responsable').value = e.RESPONSABLE || '';
+            document.getElementById('organizador').value = e.ORGANIZADOR || '';
+
+            const costoInput = document.getElementById('costo');
+            if (e.ES_PAGADO == 1) {
+                costoInput.removeAttribute('readonly');
+            } else {
+                costoInput.setAttribute('readonly', true);
+                costoInput.value = '0';
             }
-            // esPagado: checkbox
-            if (document.getElementById('esPagado')) {
-                document.getElementById('esPagado').checked = e.ES_PAGADO == 1;
-            }
-            if (document.getElementById('estado')) document.getElementById('estado').value = e.ESTADO;
-            if (document.getElementById('responsable')) document.getElementById('responsable').value = e.RESPONSABLE || '';
-            if (document.getElementById('organizador')) document.getElementById('organizador').value = e.ORGANIZADOR || '';
+
             $('#modalEvento').modal('show');
-            // Cambia el texto del botón guardar
-            if (document.getElementById('btn-save')) document.getElementById('btn-save').innerHTML = 'Actualizar';
+            document.getElementById('btn-save').innerHTML = 'Actualizar';
         });
 }
 
-// FIX: Usar FormData para enviar el id correctamente
 function eliminarEvento(id) {
     Swal.fire({
-        title: '¿Eliminar evento? ¡Advertencia!',
-        text: "Viola la integridad referencial, Si lo eliminas, se eliminarán todos los registros relacionados.",
+        title: '¿Eliminar evento?',
+        text: 'Viola la integridad referencial. Si lo eliminas, se eliminarán todos los registros relacionados.',
         icon: 'warning',
         showCancelButton: true,
         confirmButtonColor: '#d33',
@@ -139,37 +134,10 @@ function eliminarEvento(id) {
             axios.post('../controllers/EventosAdminController.php?option=eliminar', formData)
                 .then(res => {
                     if (res.data.success) {
-                        Swal.fire('Eliminado', 'Evento y registros relacionados eliminados correctamente.', 'success');
+                        Swal.fire('Eliminado', 'Evento eliminado correctamente.', 'success');
                         tablaEventos.ajax.reload();
                     } else {
-                        // Si el mensaje contiene integridad referencial, advertir al usuario
-                        if (res.data.mensaje && res.data.mensaje.toLowerCase().includes('relacion')) {
-                            Swal.fire({
-                                title: '¡Advertencia!',
-                                text: 'El evento tiene registros relacionados (inscripciones, imágenes, etc). Si continúas, se eliminarán todos los registros relacionados. ¿Deseas continuar?',
-                                icon: 'warning',
-                                showCancelButton: true,
-                                confirmButtonColor: '#d33',
-                                cancelButtonColor: '#3085d6',
-                                confirmButtonText: 'Eliminar de todas formas',
-                                cancelButtonText: 'Cancelar'
-                            }).then(confirmRes => {
-                                if (confirmRes.isConfirmed) {
-                                    // Intentar de nuevo la eliminación (el modelo ya elimina en cascada)
-                                    axios.post('../controllers/EventosAdminController.php?option=eliminar', formData)
-                                        .then(res2 => {
-                                            if (res2.data.success) {
-                                                Swal.fire('Eliminado', 'Evento y registros relacionados eliminados correctamente.', 'success');
-                                                tablaEventos.ajax.reload();
-                                            } else {
-                                                Swal.fire('Error', res2.data.mensaje, 'error');
-                                            }
-                                        });
-                                }
-                            });
-                        } else {
-                            Swal.fire('Error', res.data.mensaje, 'error');
-                        }
+                        Swal.fire('Error', res.data.mensaje, 'error');
                     }
                 });
         }
@@ -179,7 +147,7 @@ function eliminarEvento(id) {
 function cancelarEvento(id) {
     Swal.fire({
         title: '¿Cancelar evento?',
-        text: "El evento será marcado como CANCELADO.",
+        text: 'El evento será marcado como CANCELADO.',
         icon: 'warning',
         showCancelButton: true,
         confirmButtonColor: '#f39c12',
@@ -205,37 +173,71 @@ function cancelarEvento(id) {
 document.addEventListener('DOMContentLoaded', function () {
     inicializarTablaEventos();
     cargarSelectOrganizadores();
-    cargarSelectsEvento(); // NUEVO: cargar catálogos
-
-    // Manejar el checkbox para mostrar/ocultar eventos cancelados
-    const chkCancelados = document.getElementById('mostrarCancelados');
-    if (chkCancelados) {
-        chkCancelados.addEventListener('change', function () {
-            inicializarTablaEventos();
-        });
-    }
+    cargarSelectsEvento();
 
     const frm = document.getElementById('formEvento');
     const btnSave = document.getElementById('btn-save');
     const idEvento = document.getElementById('idEvento');
+    const esPagadoCheckbox = document.getElementById('esPagado');
+    const costoInput = document.getElementById('costo');
+
+    if (esPagadoCheckbox && costoInput) {
+        esPagadoCheckbox.addEventListener('change', function () {
+            if (this.checked) {
+                costoInput.removeAttribute('readonly');
+                costoInput.value = '';
+            } else {
+                costoInput.setAttribute('readonly', true);
+                costoInput.value = '0';
+            }
+        });
+
+        if (!esPagadoCheckbox.checked) {
+            costoInput.setAttribute('readonly', true);
+            costoInput.value = '0';
+        }
+    }
 
     if (frm) {
         frm.onsubmit = function (e) {
             e.preventDefault();
+
+            const titulo = document.getElementById('titulo').value.trim();
+            const descripcion = document.getElementById('descripcion').value.trim();
+            const horas = parseFloat(document.getElementById('horas').value);
+            const capacidad = parseInt(document.getElementById('capacidad').value);
+            const notaAprobacion = parseFloat(document.getElementById('notaAprobacion').value);
+            const fechaInicio = document.getElementById('fechaInicio').value;
+            const fechaFin = document.getElementById('fechaFin').value;
+            const hoy = new Date().toISOString().split('T')[0];
+            const costo = parseFloat(costoInput.value);
+            const esPagado = esPagadoCheckbox.checked;
+
+            if (titulo.length < 3) return Swal.fire('Error', 'El título debe tener al menos 3 caracteres.', 'error');
+            if (descripcion.length < 10) return Swal.fire('Error', 'La descripción debe tener al menos 10 caracteres.', 'error');
+            if (isNaN(horas) || horas <= 0) return Swal.fire('Error', 'Las horas deben ser mayores a 0.', 'error');
+            if (isNaN(capacidad) || capacidad <= 0) return Swal.fire('Error', 'La capacidad debe ser positiva.', 'error');
+            if (!isNaN(notaAprobacion) && (notaAprobacion < 0 || notaAprobacion > 100)) return Swal.fire('Error', 'Nota fuera de rango.', 'error');
+            if (fechaInicio < hoy) return Swal.fire('Error', 'Fecha de inicio inválida.', 'error');
+            if (fechaFin && fechaFin < fechaInicio) return Swal.fire('Error', 'Fecha fin menor a inicio.', 'error');
+            if (esPagado && (isNaN(costo) || costo <= 0)) return Swal.fire('Error', 'Costo requerido para eventos pagados.', 'error');
+
+            const selects = ['carrera', 'tipoEvento', 'modalidad', 'categoria', 'responsable', 'organizador'];
+            for (const id of selects) {
+                const val = document.getElementById(id).value;
+                if (!val) return Swal.fire('Error', `Debe seleccionar ${id}`, 'error');
+            }
+
             const formData = new FormData(frm);
-            // esPagado: checkbox
-            if (document.getElementById('esPagado')) {
-                formData.set('esPagado', document.getElementById('esPagado').checked ? 1 : 0);
-            }
-            // publicoDestino: select
-            if (document.getElementById('publicoDestino')) {
-                formData.set('esSoloInternos', document.getElementById('publicoDestino').value === 'internos' ? 1 : 0);
-            }
+            formData.set('esPagado', esPagado ? 1 : 0);
+            formData.set('costo', esPagado ? costoInput.value : '0');
+            formData.set('estado', 'DISPONIBLE'); // se fuerza el estado
             let url = '../controllers/EventosAdminController.php?option=crear';
-            if (idEvento && idEvento.value !== '') {
+            if (idEvento.value !== '') {
                 url = '../controllers/EventosAdminController.php?option=editar';
                 formData.append('id', idEvento.value);
             }
+
             axios.post(url, formData)
                 .then(res => {
                     if (res.data.success) {
@@ -243,7 +245,7 @@ document.addEventListener('DOMContentLoaded', function () {
                         $('#modalEvento').modal('hide');
                         tablaEventos.ajax.reload();
                         frm.reset();
-                        if (btnSave) btnSave.innerHTML = 'Guardar';
+                        btnSave.innerHTML = 'Guardar';
                     } else {
                         Swal.fire('Error', res.data.mensaje, 'error');
                     }
@@ -252,18 +254,19 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     $('#modalEvento').on('hidden.bs.modal', function () {
-        if (frm) frm.reset();
-        if (btnSave) btnSave.innerHTML = 'Guardar';
+        frm.reset();
+        btnSave.innerHTML = 'Guardar';
+        document.getElementById('costo').value = '0';
+        document.getElementById('costo').setAttribute('readonly', true);
     });
 
-    // El botón para abrir el modal tiene id="btn-nuevo"
-    const btnNuevo = document.getElementById('btn-nuevo');
-    if (btnNuevo) {
-        btnNuevo.addEventListener('click', function () {
-            if (frm) frm.reset();
-            if (idEvento) idEvento.value = '';
-            if (btnSave) btnSave.innerHTML = 'Guardar';
-            $('#modalEvento').modal('show');
-        });
-    }
+    document.getElementById('btn-nuevo')?.addEventListener('click', function (e) {
+        e.preventDefault();
+        frm.reset();
+        idEvento.value = '';
+        btnSave.innerHTML = 'Guardar';
+        document.getElementById('costo').value = '0';
+        document.getElementById('costo').setAttribute('readonly', true);
+        $('#modalEvento').modal('show');
+    });
 });

--- a/views/dashboard_Eve_Adm.php
+++ b/views/dashboard_Eve_Adm.php
@@ -47,7 +47,9 @@ include("../core/auth.php")?>
             <div class="modal-content">
 
               <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                  <span aria-hidden="true">&times;</span>
+                </button>
                 <h4 class="modal-title" id="modalEventoLabel"><i class="fa fa-edit"></i> Crear/Editar Evento</h4>
               </div>
               <div class="modal-body">
@@ -114,10 +116,17 @@ include("../core/auth.php")?>
         <label for="notaAprobacion"><i class="fa fa-check-circle"></i> Nota mínima de aprobación</label>
         <input type="number" class="form-control" id="notaAprobacion" name="notaAprobacion" min="0" step="0.1">
       </div>
+
       <div class="col-md-6">
         <label for="costo"><i class="fa fa-dollar"></i> Costo ($)</label>
-        <input type="number" class="form-control" id="costo" name="costo" min="0" step="0.01">
+        <input type="number" class="form-control" id="costo" name="costo" min="0" step="0.01" value="0" readonly>
       </div>
+    </div><br>
+
+    <!-- Capacidad -->
+    <div class="form-group">
+      <label for="capacidad"><i class="fa fa-users"></i> Capacidad del Evento</label>
+      <input type="number" class="form-control" id="capacidad" name="capacidad" min="1" step="1" required>
     </div><br>
 
    <!-- Carrera -->
@@ -148,13 +157,14 @@ include("../core/auth.php")?>
   </div>
 </div>
 <br>
+
 <!-- Público destino -->
 <div class="form-group">
   <label for="publicoDestino"><i class="fa fa-users"></i> ¿Quiénes pueden inscribirse?</label>
-  <select id="publicoDestino" name="publicoDestino" class="form-control" required>
-    <option value="internos">Internos</option>
-    <option value="externos">Externos</option>
-  </select>
+    <select id="esSoloInternos" name="esSoloInternos" class="form-control" required>
+      <option value="1">Internos</option>
+      <option value="0">Externos</option>
+    </select>
 </div>
 
     <!-- Certificado -->
@@ -171,12 +181,8 @@ include("../core/auth.php")?>
   <div id="listaRequisitos" class="form-check">
   </div>
 </div>
-    <!-- Estado -->
-    <div class="form-group">
-      <label for="estado"><i class="fa fa-flag"></i> Estado del Evento</label>
-      <select id="estado" name="estado" class="form-control" required></select>
-    </div><br>
-    <!-- Imagen de Portada -->
+
+<!-- Imagen de Portada -->
 <div class="form-group">
   <label for="urlPortada"><i class="fa fa-image"></i> Imagen de Portada</label>
   <input type="file" class="form-control" id="urlPortada" name="urlPortada" accept="image/*">

--- a/views/dashboard_Eve_Adm.php
+++ b/views/dashboard_Eve_Adm.php
@@ -41,6 +41,7 @@ include("../core/auth.php")?>
           </table>
         </div>
         
+        
 <!-- Modal -->
         <div class="modal fade" id="modalEvento" tabindex="-1" role="dialog" aria-labelledby="modalEventoLabel" aria-hidden="true">
           <div class="modal-dialog modal-lg">

--- a/views/dashboard_Eve_Adm.php
+++ b/views/dashboard_Eve_Adm.php
@@ -41,7 +41,7 @@ include("../core/auth.php")?>
           </table>
         </div>
         
-        
+
 <!-- Modal -->
         <div class="modal fade" id="modalEvento" tabindex="-1" role="dialog" aria-labelledby="modalEventoLabel" aria-hidden="true">
           <div class="modal-dialog modal-lg">
@@ -205,13 +205,14 @@ include("../core/auth.php")?>
 </div>
 
 <!-- Footer del modal -->
-<div class="modal-footer">
-  <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
-</div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+  </div>
+              </div>
             </div>
           </div>
-        </div>
-        <!-- Fin modal -->
+
+<!-- Fin modal -->
          
 
       </div>


### PR DESCRIPTION
✅ Especificación de cambios realizados por archivo

1. dashboard_Eve_Adm.php
✅ Se eliminó el campo editable de estado (<select name="estado">) en el formulario de eventos.
Ya no se puede seleccionar "Finalizado", "Cancelado", etc. al crear el evento.
El estado será automáticamente DISPONIBLE al registrar.
✅ Se agregó el campo capacidad (<input name="capacidad">) para indicar la cantidad máxima de participantes.
✅ Se mejoró el orden y consistencia del formulario.

2. eventoAdmin.js
✅ Se bloquea el campo costo si el checkbox "¿Es pagado?" no está marcado.
Si el evento es gratuito, se envía 0.00 y el campo queda readonly.
Si es pagado, se habilita y se exige un valor mayor a 0.
✅ Se validan las fechas de inicio y fin:
La fecha de inicio no puede ser menor a la fecha actual.
La fecha de fin no puede ser menor a la de inicio.
✅ Se eliminó la lógica que validaba el campo estado, ya que ahora se asigna automáticamente.
✅ Se corrigió el error de JavaScript (preventDefault is not a function) al abrir el modal.
✅ Se asegura que los campos requeridos del formulario estén correctamente validados antes del envío.

3. EventosAdminController.php
✅ Se eliminó estado de la lista de campos requeridos al crear un evento.
✅ Se asigna automáticamente ESTADO = 'DISPONIBLE' al crear un evento, desde el controlador.
✅ Se validan todos los campos necesarios, incluyendo capacidad, esPagado, costo, etc.

4. EventosAdmin.php
✅ Se actualizó el método crear() para:
Insertar el campo CAPACIDAD.
Omitir el campo ESTADO desde el formulario y asignarlo directamente como 'DISPONIBLE'.
✅ El método editar() sigue permitiendo modificar estado si ya existía un evento.
✅ Se mantuvo la lógica de asignación de organizadores y responsables.

📸 Capturas de pantalla
![image](https://github.com/user-attachments/assets/307f0b7d-fa1e-4f60-b2ce-41a3268e96d5)

![image](https://github.com/user-attachments/assets/2a8192b6-8fd3-49fe-bc3c-200b2e7acba2)

![image](https://github.com/user-attachments/assets/0a79b2ed-8273-4e19-b2b6-ef989dc030ba)

![image](https://github.com/user-attachments/assets/3d07c37d-837d-4744-b19c-add534b88029)

