### PR TITLE
Reajuste de formulario y backend

### DIFF
--- a/public/js/usuario.js
+++ b/public/js/usuario.js
@@ -1,4 +1,3 @@
-
 let tablaUsuarios;
 function inicializarTablaUsuarios() {
     if (tablaUsuarios) tablaUsuarios.destroy();
@@ -6,12 +5,13 @@ function inicializarTablaUsuarios() {
         ajax: {
             url: '../controllers/UsuarioController.php?option=listar',
             dataSrc: function (json) {
-                // Lee el valor del checkbox cada vez que se filtra
-                const mostrarInactivos = document.getElementById('mostrarInactivos')?.checked;
+                // Ocultar administradores
+                let mostrarInactivos = document.getElementById('mostrarInactivos')?.checked;
+                let filtrados = json.filter(u => u.CODIGOROL !== 'ADM');
                 if (mostrarInactivos) {
-                    return json.filter(u => u.CODIGOESTADO === 'INACTIVO');
+                    return filtrados.filter(u => u.CODIGOESTADO === 'INACTIVO');
                 }
-                return json.filter(u => u.CODIGOESTADO === 'ACTIVO');
+                return filtrados.filter(u => u.CODIGOESTADO === 'ACTIVO');
             }
         },
         columns: [
@@ -24,6 +24,7 @@ function inicializarTablaUsuarios() {
             // },
             { data: 'NOMBRES' },
             { data: 'APELLIDOS' },
+            { data: 'CEDULA' },
             { data: 'TELEFONO' },
             { data: 'DIRECCION' },
             { data: 'CORREO' },
@@ -362,5 +363,36 @@ document.addEventListener('DOMContentLoaded', function () {
         Swal.fire('Error', 'Ocurrió un error inesperado en el registro.', 'error');
       });
   };
+});
+
+// Validaciones en el formulario de usuario (modal)
+document.getElementById('formUsuario')?.addEventListener('submit', function(e) {
+    const cedula = document.getElementById('cedula')?.value.trim();
+    const telefono = document.getElementById('telefono')?.value.trim();
+    const fechaNac = document.getElementById('fecha_nacimiento')?.value;
+    const cedulaPDF = document.getElementById('cedula_pdf')?.files[0];
+    let errores = [];
+    if (cedula && !/^\d{10}$/.test(cedula)) {
+        errores.push('La cédula debe tener 10 dígitos numéricos.');
+    }
+    if (telefono && !/^09[89]\d{7}$/.test(telefono)) {
+        errores.push('El teléfono debe ser un celular ecuatoriano válido (ej: 0991234567).');
+    }
+    if (fechaNac) {
+        const hoy = new Date();
+        const fnac = new Date(fechaNac);
+        const edad = hoy.getFullYear() - fnac.getFullYear();
+        if (edad < 18 || (edad === 18 && hoy < new Date(fnac.setFullYear(fnac.getFullYear() + 18)))) {
+            errores.push('El usuario debe ser mayor de 18 años.');
+        }
+    }
+    if (cedulaPDF && cedulaPDF.type !== 'application/pdf') {
+        errores.push('El archivo de cédula debe ser PDF.');
+    }
+    if (errores.length > 0) {
+        e.preventDefault();
+        Swal.fire('Error', errores.join('<br>'), 'error');
+        return false;
+    }
 });
 // ==== FINISH VALIDACIÓN DE CONTRASEÑA ====

--- a/views/dashboard_Usu_Adm.php
+++ b/views/dashboard_Usu_Adm.php
@@ -29,6 +29,7 @@ include("../core/auth.php")?>
               <tr>
                 <th>NOMBRES</th>
                 <th>APELLIDOS</th>
+                <th>CÉDULA</th>
                 <th>TELÉFONO</th>
                 <th>DIRECCIÓN</th>
                 <th>CORREO</th>
@@ -92,11 +93,25 @@ include("../core/auth.php")?>
                                 <input type="text" class="form-control" id="direccion" name="direccion">
                             </div>
                             <div class="form-group">
+                                  <div class="form-group">
+                                <label for="fecha_nacimiento">🎂 Fecha de Nacimiento:</label>
+                                <input type="date" class="form-control" id="fecha_nacimiento" name="fecha_nacimiento" required max="<?php echo date('Y-m-d'); ?>">
+                            </div>
                                 <label for="es_interno">🏢 Es Interno:</label>
                                 <select class="form-control" id="es_interno" name="es_interno" required>
                                     <option value="1">Sí</option>
                                     <option value="0">No</option>
                                 </select>
+                            </div>
+                            <div class="form-group">
+                                <label for="cedula">🆔 Cédula:</label>
+                                <input type="text" class="form-control" id="cedula" name="cedula" required pattern="^\d{10}$" maxlength="10" title="Ingrese 10 dígitos numéricos">
+                            </div>
+                          
+                            <div class="form-group">
+                                <label for="cedula_pdf">📄 Cédula (PDF):</label>
+                                <input type="file" class="form-control-file" id="cedula_pdf" name="cedula_pdf" accept="application/pdf">
+                                <small class="form-text text-muted">Solo PDF. Opcional en edición si ya existe.</small>
                             </div>
                             <div class="form-group">
                                 <label for="foto_perfil">🖼️ Foto de Perfil:</label>
@@ -110,6 +125,7 @@ include("../core/auth.php")?>
                                     <option value="BLOQUEADO">Bloqueado</option>
                                 </select>
                             </div>
+                            
                             <button type="submit" class="btn btn-primary" id="btn-save-usuario">💾 Guardar usuario</button>
                             <button type="button" class="btn btn-secondary" data-dismiss="modal">❌ Cancelar</button>
                         </form>
@@ -147,4 +163,15 @@ include("../core/auth.php")?>
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
 <script src="../public/js/usuario.js"></script>
+<script>
+document.getElementById('cedula_pdf')?.addEventListener('change', function() {
+    if (this.files.length > 0) {
+        const file = this.files[0];
+        if (file.type !== 'application/pdf') {
+            Swal.fire('Archivo inválido', 'Solo se permite subir archivos PDF para la cédula.', 'warning');
+            this.value = '';
+        }
+    }
+});
+</script>
 <?php include("partials/footer_Admin.php"); ?>


### PR DESCRIPTION
**1. Agregar campos faltantes en el formulario de registro de usuarios**
Campos agregados:
CEDULA:campo de texto, 10 dígitos, único
FECHA_NACIMIENTO:campo de fecha
URL_CEDULA archivo PDF de la cédula
Dónde:
Se añadieron estos campos en el formulario de registro/edición de usuario para administradores dashboard_Usu_Adm.php y en la tabla de usuarios.
![image](https://github.com/user-attachments/assets/95d3e6ee-f209-4152-8dc8-1d07cc61cddd)

![image](https://github.com/user-attachments/assets/0dd4077a-b1af-497e-9ec4-d285061bc4ae)

**2. Validaciones pertinentes en los diferentes campos**
Cédula:
Se valida que tenga exactamente 10 dígitos numéricos.
Se valida que la cédula sea única (no se permite duplicados en la base de datos).
Fecha de nacimiento:
Se valida que el usuario tenga al menos 18 años.
Archivo de cédula:
Solo se permite subir archivos PDF para la cédula.
![image](https://github.com/user-attachments/assets/614d6146-908c-4d15-a0d7-e75302fd415c)

![image](https://github.com/user-attachments/assets/9265b089-9f5c-4e6e-8119-be2107b7a2b0)
![image](https://github.com/user-attachments/assets/f49bd246-1715-4afc-9c78-02a73ccd191d)

**3. CRUD funcionando correctamente**
Inserción y edición:
El backend y frontend soportan los nuevos campos y validaciones.
No se permite registrar ni editar usuarios con cédula o correo duplicados.
Visualización:
La columna CÉDULA se muestra en la tabla de usuarios.
Eliminación e inactivación:
Se mantienen las funciones de eliminar e inactivar usuarios, respetando las validaciones y filtros.
![image](https://github.com/user-attachments/assets/391bc0e0-ac3e-44a0-9574-e1b4aeb860af)

