### PR TITLE
Feature/g 32 documento de descarga

### DIFF
--- a/views/generar_reporte_asistentes.php
+++ b/views/generar_reporte_asistentes.php
@@ -1,4 +1,10 @@
 <?php
+// Habilitar la visualización de errores para depuración.
+// ¡Recuerda eliminar o comentar estas líneas en un entorno de producción!
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
+
 require_once '../vendor/autoload.php';
 require_once '../controllers/EventoAsistenciaController.php';
 
@@ -26,58 +32,132 @@ $fechaGeneracion = date('Y-m-d H:i:s');
 // Comenzar HTML
 $html = '
 <style>
-    body { font-family: Arial, sans-serif; font-size: 12px; }
-    h2, h4 { text-align: center; }
-
-    .header {
+    body {
+        font-family: Arial, sans-serif;
+        font-size: 12px;
+        margin: 0;
+        padding: 0;
+    }
+    h2 {
         text-align: center;
-        margin-bottom: 20px;
+        margin-top: 25px; /* Un poco más de margen para que no se pegue al encabezado */
+        margin-bottom: 15px;
+        color: #B71C1C; /* Color rojo */
+        font-size: 18px;
     }
-    .header img {
-        height: 70px;
-        margin: 0 20px;
-    }
-    .uta-header {
+    .main-header { /* Nuevo contenedor para la cabecera principal */
+        background-color: #B71C1C; /* Fondo rojo para la cabecera */
+        color: white; /* Texto blanco en la cabecera */
+        padding: 10px 20px; /* Padding interno */
         display: flex;
-        justify-content: center;
         align-items: center;
-        gap: 20px;
+        justify-content: center; /* Centrar el contenido */
+        width: 100%;
+        box-sizing: border-box; /* Incluye padding en el ancho total */
     }
-    .section-title {
-        background-color: #004080;
-        color: white;
-        padding: 6px;
+    .main-header-text {
+        text-align: center; /* Centrar el texto */
+    }
+    .main-header-text h3, .main-header-text h4, .main-header-text p {
+        margin: 0;
+        line-height: 1.2;
+        color: white; /* Texto blanco */
+    }
+    .section-title { /* Para "RESUMEN DEL EVENTO" o "Listado de Asistentes" */
+        background-color: #f2f2f2; /* Color de fondo gris claro */
+        color: #333; /* Texto oscuro */
+        padding: 6px 10px;
+        font-weight: bold;
         margin-top: 20px;
+        border-bottom: 1px solid #ccc; /* Línea debajo */
     }
-    table {
+    .stats-table { /* Para el resumen del evento */
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 5px;
+        font-size: 11px;
+    }
+    .stats-table td {
+        padding: 4px;
+        border: none; /* Sin bordes en esta tabla de resumen */
+        background-color: #f2f2f2;
+    }
+    .stats-table td:first-child {
+        font-weight: bold;
+        width: 150px; /* Ancho fijo para las etiquetas */
+    }
+
+    p {
+        margin: 4px 0;
+    }
+    table { /* Tabla de datos principal (responsables y asistentes) */
         border-collapse: collapse;
         width: 100%;
         margin-top: 10px;
-    }
-    th, td {
-        border: 1px solid #ddd;
-        padding: 6px;
-        text-align: left;
+        font-size: 11px;
     }
     th {
-        background-color: #f2f2f2;
+        background-color: #B71C1C; /* Color rojo para los encabezados de tabla */
+        color: white;
+        padding: 6px;
+        border: 1px solid #B71C1C; /* Borde rojo para celdas */
+        text-align: left;
+    }
+    td {
+        border: 1px solid #ccc;
+        padding: 5px;
+        background-color: #fff;
+    }
+    tbody tr:nth-child(even) {
+        background-color: #f8d7da; /* Color para filas pares (similar al rojo claro) */
+    }
+    tbody tr:nth-child(odd) {
+        background-color: #ffffff;
+    }
+    ul {
+        list-style: none; /* Eliminar viñetas predeterminadas */
+        padding: 0;
+        margin: 10px 0;
+    }
+    ul li {
+        margin-bottom: 5px;
+        background-color: #f2f2f2; /* Fondo gris claro para los ítems de la lista */
+        padding: 4px 8px;
+        border-left: 3px solid #B71C1C; /* Barra lateral roja para los ítems de la lista */
     }
 </style>
 
-<div class="header">
-    <div class="uta-header">
-        <div>
-            <h3>UNIVERSIDAD TÉCNICA DE AMBATO</h3>
-            <h4>Facultad de Ingeniería en Sistemas, Electrónica e Industrial</h4>
-        </div>
+<div class="main-header">
+    <div class="main-header-text">
+        <h3>UNIVERSIDAD TÉCNICA DE AMBATO</h3>
+        <h4>FACULTAD DE INGENIERÍA EN SISTEMAS</h4>
+        <p>SISTEMA DE GESTIÓN ESTUDIANTIL</p>
     </div>
 </div>
 
 <h2>Reporte de Evento y Asistentes</h2>
-<p><strong>Evento:</strong> ' . htmlspecialchars($eventoNombre) . '</p>
-<p><strong>Fecha del Evento:</strong> ' . $fechaInicio . ' al ' . $fechaFin . '</p>
-<p><strong>Fecha de Generación:</strong> ' . $fechaGeneracion . '</p>
 
+<div class="section-title">RESUMEN DEL EVENTO</div>
+<table class="stats-table">
+    <tr>
+        <td><strong>Evento:</strong></td>
+        <td>' . htmlspecialchars($eventoNombre) . '</td>
+    </tr>
+    <tr>
+        <td><strong>Fechas:</strong></td>
+        <td>' . $fechaInicio . ' al ' . $fechaFin . '</td>
+    </tr>
+    <tr>
+        <td><strong>Fecha de Generación:</strong></td>
+        <td>' . $fechaGeneracion . '</td>
+    </tr>
+    <tr>
+        <td><strong>Total de Asistentes:</strong></td>
+        <td>' . count($asistentes) . '</td>
+    </tr>
+</table>
+
+<br>
 <div class="section-title">Responsables</div>
 <ul>';
 foreach ($responsables as $r) {
@@ -117,10 +197,12 @@ $html .= '</tbody></table>';
 // Generar PDF
 $dompdf = new Dompdf();
 $dompdf->loadHtml($html);
-$dompdf->setPaper('A4', 'portrait');
+$dompdf->setPaper('A4', 'portrait'); // Manteniendo portrait como estaba en tu código original
 $dompdf->render();
 
 $nombreArchivoEvento = preg_replace('/[^a-zA-Z0-9_-]/', '_', $eventoNombre);
 $filename = "reporte_asistentes_" . $nombreArchivoEvento . ".pdf";
 $dompdf->stream($filename, ["Attachment" => true]);
 exit;
+
+?>

--- a/views/generar_reporte_certificados.php
+++ b/views/generar_reporte_certificados.php
@@ -1,4 +1,10 @@
 <?php
+// Habilitar la visualización de errores para depuración.
+// ¡Recuerda eliminar o comentar estas líneas en un entorno de producción!
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
+
 require_once '../vendor/autoload.php';
 require_once '../controllers/CertificadoController.php';
 
@@ -19,77 +25,125 @@ if (empty($certificados)) {
 $eventoNombre = htmlspecialchars($certificados[0]['NOMBRE_EVENTO']);
 $fechaGeneracion = date('Y-m-d H:i:s');
 
+// --- SE ELIMINÓ TODO EL CÓDIGO RELACIONADO CON LA IMAGEN DEL LOGO AQUÍ ---
+
+
 $html = '
 <style>
-<style>
     body {
-    font-family: Arial, sans-serif; font-size: 12px;
+        font-family: Arial, sans-serif;
+        font-size: 12px;
+        margin: 0;
+        padding: 0;
     }
     h2 {
         text-align: center;
-        margin-top: 10px;
+        margin-top: 25px; /* Un poco más de margen para que no se pegue al encabezado */
+        margin-bottom: 15px;
+        color: #B71C1C; /* Color rojo */
+        font-size: 18px;
     }
-    .header {
-        text-align: center;
-        margin-bottom: 20px;
-    }
-    .uta-header {
-        display: flex;
-        justify-content: center;
+    .main-header { /* Nuevo contenedor para la cabecera principal */
+        background-color: #B71C1C; /* Fondo rojo para la cabecera */
+        color: white; /* Texto blanco en la cabecera */
+        padding: 10px 20px; /* Padding interno */
+        display: flex; /* Mantenemos flex para centrar o alinear el texto si no hay logo */
         align-items: center;
-        gap: 20px;
+        justify-content: center; /* CAMBIO: Centrar el contenido si no hay logo */
+        width: 100%;
+        box-sizing: border-box; /* Incluye padding en el ancho total */
     }
-    .header img {
-        height: 70px;
+    /* SE ELIMINÓ EL CSS DE main-header img */
+    .main-header-text {
+        text-align: center; /* CAMBIO: Centrar el texto ya que no hay logo a su lado */
+        /* margin-left: auto; -- ESTO YA NO ES NECESARIO SI EL CONTENIDO ESTÁ CENTRADO */
     }
-    .section-title {
-        background-color: #004080
+    .main-header-text h3, .main-header-text h4, .main-header-text p {
+        margin: 0;
+        line-height: 1.2;
+        color: white; /* Texto blanco */
+    }
+    .section-title { /* Para "RESUMEN ESTADÍSTICO" en el ejemplo */
+        background-color: #f2f2f2; /* Color de fondo gris claro */
+        color: #333; /* Texto oscuro */
         padding: 6px 10px;
         font-weight: bold;
         margin-top: 20px;
+        border-bottom: 1px solid #ccc; /* Línea debajo */
     }
+    .stats-table { /* Para el resumen estadístico */
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 5px;
+        font-size: 11px;
+    }
+    .stats-table td {
+        padding: 4px;
+        border: none; /* Sin bordes en esta tabla de resumen */
+        background-color: #f2f2f2;
+    }
+    .stats-table td:first-child {
+        font-weight: bold;
+        width: 150px; /* Ancho fijo para las etiquetas */
+    }
+
     p {
         margin: 4px 0;
     }
-    table {
+    table { /* Tabla de datos principal */
         border-collapse: collapse;
         width: 100%;
         margin-top: 10px;
         font-size: 11px;
     }
     th {
-        background-color: #004080;
+        background-color: #B71C1C; /* Color rojo para los encabezados de tabla */
         color: white;
         padding: 6px;
-        border: 1px solid #ccc;
+        border: 1px solid #B71C1C; /* Borde rojo para celdas */
         text-align: left;
     }
     td {
         border: 1px solid #ccc;
         padding: 5px;
+        background-color: #fff;
     }
     tbody tr:nth-child(even) {
-        background-color: #f2f2f2;
+        background-color: #f8d7da; /* Color para filas pares (similar al rojo claro) */
     }
     tbody tr:nth-child(odd) {
         background-color: #ffffff;
     }
 </style>
 
-
-
-<div class="header">
-    <div class="uta-header">
-        <div>
-            <h3>UNIVERSIDAD TÉCNICA DE AMBATO</h3>
-            <h4>Facultad de Ingeniería en Sistemas, Electrónica e Industrial - FISEI</h4>
-        </div>
+<div class="main-header">
+    <div class="main-header-text">
+        <h3>UNIVERSIDAD TÉCNICA DE AMBATO</h3>
+        <h4>FACULTAD DE INGENIERÍA EN SISTEMAS</h4>
+        <p>SISTEMA DE GESTIÓN ESTUDIANTIL</p>
     </div>
 </div>
 
 <h2>Reporte de Certificados Emitidos</h2>
-<p><strong>Evento:</strong> ' . $eventoNombre . '</p>
-<p><strong>Fecha de Generación:</strong> ' . $fechaGeneracion . '</p>
+
+<div class="section-title">RESUMEN DEL EVENTO</div>
+<table class="stats-table">
+    <tr>
+        <td><strong>Evento:</strong></td>
+        <td>' . $eventoNombre . '</td>
+    </tr>
+    <tr>
+        <td><strong>Fecha de Generación:</strong></td>
+        <td>' . $fechaGeneracion . '</td>
+    </tr>
+    <tr>
+        <td><strong>Total de Certificados:</strong></td>
+        <td>' . count($certificados) . '</td>
+    </tr>
+</table>
+
+<br>
+<div class="section-title">DETALLE DE CERTIFICADOS</div>
 
 <table>
     <thead>
@@ -126,3 +180,5 @@ $nombreArchivoEvento = preg_replace('/[^a-zA-Z0-9_-]/', '_', $eventoNombre);
 $filename = "reporte_certificados_" . $nombreArchivoEvento . ".pdf";
 $dompdf->stream($filename, ["Attachment" => true]);
 exit;
+
+?>

--- a/views/generar_reporte_eventos_categoria.php
+++ b/views/generar_reporte_eventos_categoria.php
@@ -1,4 +1,10 @@
 <?php
+// Habilitar la visualización de errores para depuración.
+// ¡Recuerda eliminar o comentar estas líneas en un entorno de producción!
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
+
 require_once '../vendor/autoload.php';
 require_once '../controllers/EventoCategoriaController.php';
 
@@ -30,67 +36,117 @@ if (empty($eventos)) {
 // Construcción del HTML
 $html = '
 <style>
-    body { font-family: Arial, sans-serif; font-size: 12px; }
-    h2 { text-align: center; margin-top: 10px; }
-    .header {
+    body {
+        font-family: Arial, sans-serif;
+        font-size: 12px;
+        margin: 0;
+        padding: 0;
+    }
+    h2 {
         text-align: center;
-        margin-bottom: 20px;
+        margin-top: 25px; /* Un poco más de margen para que no se pegue al encabezado */
+        margin-bottom: 15px;
+        color: #B71C1C; /* Color rojo */
+        font-size: 18px;
     }
-    .uta-header {
+    .main-header { /* Nuevo contenedor para la cabecera principal */
+        background-color: #B71C1C; /* Fondo rojo para la cabecera */
+        color: white; /* Texto blanco en la cabecera */
+        padding: 10px 20px; /* Padding interno */
         display: flex;
-        justify-content: center;
         align-items: center;
-        gap: 20px;
+        justify-content: center; /* Centrar el contenido */
+        width: 100%;
+        box-sizing: border-box; /* Incluye padding en el ancho total */
     }
-    .header img {
-        height: 70px;
+    .main-header-text {
+        text-align: center; /* Centrar el texto */
     }
-    .section-title {
-        background-color: #004080;
-        color: white;
+    .main-header-text h3, .main-header-text h4, .main-header-text p {
+        margin: 0;
+        line-height: 1.2;
+        color: white; /* Texto blanco */
+    }
+    .section-title { /* Para "RESUMEN DEL REPORTE" o "Listado de Eventos" */
+        background-color: #f2f2f2; /* Color de fondo gris claro */
+        color: #333; /* Texto oscuro */
         padding: 6px 10px;
         font-weight: bold;
         margin-top: 20px;
+        border-bottom: 1px solid #ccc; /* Línea debajo */
     }
-    p { margin: 4px 0; }
-    table {
+    .stats-table { /* Para el resumen del reporte */
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 5px;
+        font-size: 11px;
+    }
+    .stats-table td {
+        padding: 4px;
+        border: none; /* Sin bordes en esta tabla de resumen */
+        background-color: #f2f2f2;
+    }
+    .stats-table td:first-child {
+        font-weight: bold;
+        width: 150px; /* Ancho fijo para las etiquetas */
+    }
+
+    p {
+        margin: 4px 0;
+    }
+    table { /* Tabla de datos principal (Listado de Eventos) */
         border-collapse: collapse;
         width: 100%;
         margin-top: 10px;
         font-size: 11px;
     }
     th {
-        background-color: #004080;
+        background-color: #B71C1C; /* Color rojo para los encabezados de tabla */
         color: white;
         padding: 6px;
-        border: 1px solid #ccc;
+        border: 1px solid #B71C1C; /* Borde rojo para celdas */
         text-align: left;
     }
     td {
         border: 1px solid #ccc;
         padding: 5px;
+        background-color: #fff;
     }
     tbody tr:nth-child(even) {
-        background-color: #f2f2f2;
+        background-color: #f8d7da; /* Color para filas pares (similar al rojo claro) */
     }
     tbody tr:nth-child(odd) {
         background-color: #ffffff;
     }
 </style>
 
-<div class="header">
-    <div class="uta-header">
-        <div>
-            <h3>UNIVERSIDAD TÉCNICA DE AMBATO</h3>
-            <h4>Facultad de Ingeniería en Sistemas, Electrónica e Industrial - FISEI</h4>
-        </div>
+<div class="main-header">
+    <div class="main-header-text">
+        <h3>UNIVERSIDAD TÉCNICA DE AMBATO</h3>
+        <h4>FACULTAD DE INGENIERÍA EN SISTEMAS</h4>
+        <p>SISTEMA DE GESTIÓN ESTUDIANTIL</p>
     </div>
 </div>
 
 <h2>Reporte de Eventos por Categoría</h2>
-<p><strong>Categoría:</strong> ' . htmlspecialchars($categoriaNombre) . '</p>
-<p><strong>Fecha de Generación:</strong> ' . $fechaGeneracion . '</p>
 
+<div class="section-title">RESUMEN DEL REPORTE</div>
+<table class="stats-table">
+    <tr>
+        <td><strong>Categoría Seleccionada:</strong></td>
+        <td>' . htmlspecialchars($categoriaNombre) . '</td>
+    </tr>
+    <tr>
+        <td><strong>Fecha de Generación:</strong></td>
+        <td>' . $fechaGeneracion . '</td>
+    </tr>
+    <tr>
+        <td><strong>Total de Eventos:</strong></td>
+        <td>' . count($eventos) . '</td>
+    </tr>
+</table>
+
+<br>
 <div class="section-title">Listado de Eventos</div>
 <table>
     <thead>
@@ -127,9 +183,11 @@ $html .= '</tbody></table>';
 // Generar PDF
 $dompdf = new Dompdf();
 $dompdf->loadHtml($html);
-$dompdf->setPaper('A4', 'landscape');
+$dompdf->setPaper('A4', 'landscape'); // Manteniendo landscape como en tu código original
 $dompdf->render();
 
 $nombreArchivo = preg_replace('/[^a-zA-Z0-9_-]/', '_', $categoriaNombre);
 $dompdf->stream("reporte_eventos_" . $nombreArchivo . ".pdf", ["Attachment" => true]);
 exit;
+
+?>

--- a/views/generar_reporte_financiero.php
+++ b/views/generar_reporte_financiero.php
@@ -1,4 +1,10 @@
 <?php
+// Habilitar la visualización de errores para depuración.
+// ¡Recuerda eliminar o comentar estas líneas en un entorno de producción!
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
+
 require_once '../vendor/autoload.php';
 require_once '../controllers/FinancieroController.php';
 
@@ -11,7 +17,7 @@ if (!isset($_POST['evento'])) {
 $eventoId = intval($_POST['evento']);
 $controller = new FinancieroController();
 $reporte = $controller->obtenerReporte($eventoId);
-$nombreEvento = $controller->obtenerNombreEvento($eventoId);
+$nombreEvento = $controller->obtenerNombreEvento($eventoId); // Asumo que esto devuelve el nombre directamente
 $fechaGeneracion = date('d/m/Y H:i');
 
 $montos = $reporte['montos'];
@@ -21,79 +27,136 @@ $comprobantes = $reporte['comprobantes'];
 // Iniciar HTML
 $html = '
 <style>
-    body { font-family: Arial, sans-serif; font-size: 12px; }
-    h2 { text-align: center; margin-top: 10px; }
-    .header {
+    body {
+        font-family: Arial, sans-serif;
+        font-size: 12px;
+        margin: 0;
+        padding: 0;
+    }
+    h2 {
         text-align: center;
-        margin-bottom: 20px;
+        margin-top: 25px; /* Un poco más de margen para que no se pegue al encabezado */
+        margin-bottom: 15px;
+        color: #B71C1C; /* Color rojo */
+        font-size: 18px;
     }
-    .uta-header {
+    .main-header { /* Nuevo contenedor para la cabecera principal */
+        background-color: #B71C1C; /* Fondo rojo para la cabecera */
+        color: white; /* Texto blanco en la cabecera */
+        padding: 10px 20px; /* Padding interno */
         display: flex;
-        justify-content: center;
         align-items: center;
-        gap: 20px;
+        justify-content: center; /* Centrar el contenido */
+        width: 100%;
+        box-sizing: border-box; /* Incluye padding en el ancho total */
     }
-    .header img {
-        height: 70px;
+    .main-header-text {
+        text-align: center; /* Centrar el texto */
     }
-    .section-title {
-        background-color: #004080;
-        color: white;
+    .main-header-text h3, .main-header-text h4, .main-header-text p {
+        margin: 0;
+        line-height: 1.2;
+        color: white; /* Texto blanco */
+    }
+    .section-title { /* Para "Recaudación por Forma de Pago", etc. */
+        background-color: #f2f2f2; /* Color de fondo gris claro */
+        color: #333; /* Texto oscuro */
         padding: 6px 10px;
         font-weight: bold;
         margin-top: 20px;
+        border-bottom: 1px solid #ccc; /* Línea debajo */
     }
-    p { margin: 4px 0; }
-    table {
+    .stats-table { /* Para el resumen general del reporte */
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 5px;
+        font-size: 11px;
+    }
+    .stats-table td {
+        padding: 4px;
+        border: none; /* Sin bordes en esta tabla de resumen */
+        background-color: #f2f2f2;
+    }
+    .stats-table td:first-child {
+        font-weight: bold;
+        width: 150px; /* Ancho fijo para las etiquetas */
+    }
+
+    p {
+        margin: 4px 0;
+    }
+    table { /* Tablas de datos principales */
         border-collapse: collapse;
         width: 100%;
         margin-top: 10px;
         font-size: 11px;
     }
     th {
-        background-color: #004080;
+        background-color: #B71C1C; /* Color rojo para los encabezados de tabla */
         color: white;
         padding: 6px;
-        border: 1px solid #ccc;
+        border: 1px solid #B71C1C; /* Borde rojo para celdas */
         text-align: left;
     }
     td {
         border: 1px solid #ccc;
         padding: 5px;
+        background-color: #fff;
     }
     tbody tr:nth-child(even) {
-        background-color: #f2f2f2;
+        background-color: #f8d7da; /* Color para filas pares (similar al rojo claro) */
     }
     tbody tr:nth-child(odd) {
         background-color: #ffffff;
     }
+    .total-row {
+        font-weight: bold;
+        background-color: #e0e0e0 !important; /* Un gris más oscuro para el total */
+    }
 </style>
 
-<div class="header">
-    <div class="uta-header">
-        <div>
-            <h3>UNIVERSIDAD TÉCNICA DE AMBATO</h3>
-            <h4>Facultad de Ingeniería en Sistemas, Electrónica e Industrial - FISEI</h4>
-        </div>
+<div class="main-header">
+    <div class="main-header-text">
+        <h3>UNIVERSIDAD TÉCNICA DE AMBATO</h3>
+        <h4>FACULTAD DE INGENIERÍA EN SISTEMAS</h4>
+        <p>SISTEMA DE GESTIÓN ESTUDIANTIL</p>
     </div>
 </div>
 
-<h2>Reporte Financiero</h2>
-<p><strong>Evento:</strong> ' . htmlspecialchars($nombreEvento) . '</p>
-<p><strong>Fecha de generación:</strong> ' . $fechaGeneracion . '</p>
+<h2>Reporte Financiero del Evento</h2>
 
+<div class="section-title">RESUMEN DEL REPORTE</div>
+<table class="stats-table">
+    <tr>
+        <td><strong>Evento:</strong></td>
+        <td>' . htmlspecialchars($nombreEvento) . '</td>
+    </tr>
+    <tr>
+        <td><strong>Fecha de Generación:</strong></td>
+        <td>' . $fechaGeneracion . '</td>
+    </tr>
+</table>
+
+<br>
 <div class="section-title">1. Recaudación por Forma de Pago</div>
 <table>
     <thead>
         <tr><th>Forma de Pago</th><th>Total Recaudado</th></tr>
     </thead>
     <tbody>';
+$totalRecaudadoGeneral = 0;
 foreach ($montos as $m) {
     $html .= '<tr>';
     $html .= '<td>' . htmlspecialchars($m['FORMA_PAGO']) . '</td>';
     $html .= '<td>$' . number_format($m['TOTAL_RECAUDADO'], 2) . '</td>';
     $html .= '</tr>';
+    $totalRecaudadoGeneral += $m['TOTAL_RECAUDADO'];
 }
+// Fila para el total recaudado
+$html .= '<tr class="total-row">';
+$html .= '<td><strong>TOTAL RECAUDADO:</strong></td>';
+$html .= '<td><strong>$' . number_format($totalRecaudadoGeneral, 2) . '</strong></td>';
+$html .= '</tr>';
 $html .= '</tbody></table>';
 
 $html .= '<div class="section-title">2. Pagos Pendientes</div>
@@ -105,6 +168,7 @@ $html .= '<div class="section-title">2. Pagos Pendientes</div>
         </tr>
     </thead>
     <tbody>';
+$totalPendiente = 0;
 foreach ($pendientes as $p) {
     $html .= '<tr>';
     $html .= '<td>' . htmlspecialchars($p['NOMBRE_COMPLETO']) . '</td>';
@@ -114,7 +178,14 @@ foreach ($pendientes as $p) {
     $html .= '<td>' . htmlspecialchars($p['ESTADO']) . '</td>';
     $html .= '<td>' . ($p['FECHA_PAGO'] ? $p['FECHA_PAGO']->format('Y-m-d') : '-') . '</td>';
     $html .= '</tr>';
+    $totalPendiente += $p['MONTO'];
 }
+// Fila para el total pendiente
+$html .= '<tr class="total-row">';
+$html .= '<td colspan="3"><strong>TOTAL PENDIENTE:</strong></td>';
+$html .= '<td><strong>$' . number_format($totalPendiente, 2) . '</strong></td>';
+$html .= '<td colspan="2"></td>'; // Celdas vacías para completar la fila
+$html .= '</tr>';
 $html .= '</tbody></table>';
 
 $html .= '<div class="section-title">3. Comprobantes Subidos</div>
@@ -123,6 +194,7 @@ $html .= '<div class="section-title">3. Comprobantes Subidos</div>
         <tr><th>Nombre</th><th>Correo</th><th>Monto</th><th>Comprobante</th><th>Estado</th></tr>
     </thead>
     <tbody>';
+$totalComprobantes = 0;
 foreach ($comprobantes as $c) {
     $html .= '<tr>';
     $html .= '<td>' . htmlspecialchars($c['NOMBRE_COMPLETO']) . '</td>';
@@ -131,16 +203,25 @@ foreach ($comprobantes as $c) {
     $html .= '<td>' . htmlspecialchars($c['COMPROBANTE_URL']) . '</td>';
     $html .= '<td>' . htmlspecialchars($c['ESTADO']) . '</td>';
     $html .= '</tr>';
+    $totalComprobantes += $c['MONTO'];
 }
+// Fila para el total de comprobantes subidos
+$html .= '<tr class="total-row">';
+$html .= '<td colspan="2"><strong>TOTAL COMPROBANTES:</strong></td>';
+$html .= '<td><strong>$' . number_format($totalComprobantes, 2) . '</strong></td>';
+$html .= '<td colspan="2"></td>'; // Celdas vacías para completar la fila
+$html .= '</tr>';
 $html .= '</tbody></table>';
 
 // Generar PDF
 $dompdf = new Dompdf();
 $dompdf->loadHtml($html);
-$dompdf->setPaper('A4', 'portrait');
+$dompdf->setPaper('A4', 'portrait'); // Manteniendo portrait como en tu código original
 $dompdf->render();
 
 $nombreLimpio = preg_replace('/[^A-Za-z0-9_\-]/', '_', $nombreEvento);
 $filename = "reporte_financiero_" . $nombreLimpio . ".pdf";
 $dompdf->stream($filename, ["Attachment" => true]);
 exit;
+
+?>

--- a/views/generar_reporte_inscripciones.php
+++ b/views/generar_reporte_inscripciones.php
@@ -1,4 +1,10 @@
 <?php
+// Habilitar la visualización de errores para depuración.
+// ¡Recuerda eliminar o comentar estas líneas en un entorno de producción!
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
+
 require_once '../vendor/autoload.php';
 require_once '../controllers/InscripcionController.php';
 
@@ -12,7 +18,7 @@ $eventoId = intval($_POST['evento']);
 $controller = new InscripcionController();
 $reporte = $controller->obtenerReporte($eventoId);
 $inscritos = $reporte['datos'];
-$total = $reporte['total'];
+$totalInscritos = $reporte['total']; // Renombrado a $totalInscritos para mayor claridad
 
 if (empty($inscritos)) {
     die("No hay inscritos para este evento.");
@@ -23,68 +29,117 @@ $fechaGeneracion = date('Y-m-d H:i:s');
 // Construcción del HTML
 $html = '
 <style>
-    body { font-family: Arial, sans-serif; font-size: 12px; }
-    h2 { text-align: center; margin-top: 10px; }
-    .header {
+    body {
+        font-family: Arial, sans-serif;
+        font-size: 12px;
+        margin: 0;
+        padding: 0;
+    }
+    h2 {
         text-align: center;
-        margin-bottom: 20px;
+        margin-top: 25px; /* Un poco más de margen para que no se pegue al encabezado */
+        margin-bottom: 15px;
+        color: #B71C1C; /* Color rojo */
+        font-size: 18px;
     }
-    .uta-header {
+    .main-header { /* Nuevo contenedor para la cabecera principal */
+        background-color: #B71C1C; /* Fondo rojo para la cabecera */
+        color: white; /* Texto blanco en la cabecera */
+        padding: 10px 20px; /* Padding interno */
         display: flex;
-        justify-content: center;
         align-items: center;
-        gap: 20px;
+        justify-content: center; /* Centrar el contenido */
+        width: 100%;
+        box-sizing: border-box; /* Incluye padding en el ancho total */
     }
-    .header img {
-        height: 70px;
+    .main-header-text {
+        text-align: center; /* Centrar el texto */
     }
-    .section-title {
-        background-color: #004080;
-        color: white;
+    .main-header-text h3, .main-header-text h4, .main-header-text p {
+        margin: 0;
+        line-height: 1.2;
+        color: white; /* Texto blanco */
+    }
+    .section-title { /* Para "RESUMEN DEL REPORTE" o "Listado de Inscritos" */
+        background-color: #f2f2f2; /* Color de fondo gris claro */
+        color: #333; /* Texto oscuro */
         padding: 6px 10px;
         font-weight: bold;
         margin-top: 20px;
+        border-bottom: 1px solid #ccc; /* Línea debajo */
     }
-    p { margin: 4px 0; }
-    table {
+    .stats-table { /* Para el resumen del reporte */
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 5px;
+        font-size: 11px;
+    }
+    .stats-table td {
+        padding: 4px;
+        border: none; /* Sin bordes en esta tabla de resumen */
+        background-color: #f2f2f2;
+    }
+    .stats-table td:first-child {
+        font-weight: bold;
+        width: 150px; /* Ancho fijo para las etiquetas */
+    }
+
+    p {
+        margin: 4px 0;
+    }
+    table { /* Tabla de datos principal (Listado de Inscritos) */
         border-collapse: collapse;
         width: 100%;
         margin-top: 10px;
         font-size: 11px;
     }
     th {
-        background-color: #004080;
+        background-color: #B71C1C; /* Color rojo para los encabezados de tabla */
         color: white;
         padding: 6px;
-        border: 1px solid #ccc;
+        border: 1px solid #B71C1C; /* Borde rojo para celdas */
         text-align: left;
     }
     td {
         border: 1px solid #ccc;
         padding: 5px;
+        background-color: #fff;
     }
     tbody tr:nth-child(even) {
-        background-color: #f2f2f2;
+        background-color: #f8d7da; /* Color para filas pares (similar al rojo claro) */
     }
     tbody tr:nth-child(odd) {
         background-color: #ffffff;
     }
 </style>
 
-<div class="header">
-    <div class="uta-header">
-        <div>
-            <h3>UNIVERSIDAD TÉCNICA DE AMBATO</h3>
-            <h4>Facultad de Ingeniería en Sistemas, Electrónica e Industrial - FISEI</h4>
-        </div>
+<div class="main-header">
+    <div class="main-header-text">
+        <h3>UNIVERSIDAD TÉCNICA DE AMBATO</h3>
+        <h4>FACULTAD DE INGENIERÍA EN SISTEMAS</h4>
+        <p>SISTEMA DE GESTIÓN ESTUDIANTIL</p>
     </div>
 </div>
 
 <h2>Reporte de Inscripciones</h2>
-<p><strong>ID del Evento:</strong> ' . $eventoId . '</p>
-<p><strong>Total Inscritos:</strong> ' . $total . '</p>
-<p><strong>Fecha de Generación:</strong> ' . $fechaGeneracion . '</p>
 
+<div class="section-title">RESUMEN DEL REPORTE</div>
+<table class="stats-table">
+    <tr>
+        <td><strong>ID del Evento:</strong></td>
+        <td>' . htmlspecialchars($eventoId) . '</td>
+    </tr>
+    <tr>
+        <td><strong>Total de Inscritos:</strong></td>
+        <td>' . htmlspecialchars($totalInscritos) . '</td>
+    </tr>
+    <tr>
+        <td><strong>Fecha de Generación:</strong></td>
+        <td>' . $fechaGeneracion . '</td>
+    </tr>
+</table>
+
+<br>
 <div class="section-title">Listado de Inscritos</div>
 <table>
     <thead>
@@ -111,9 +166,11 @@ $html .= '</tbody></table>';
 // Generar PDF
 $dompdf = new Dompdf();
 $dompdf->loadHtml($html);
-$dompdf->setPaper('A4', 'portrait');
+$dompdf->setPaper('A4', 'portrait'); // Manteniendo portrait como en tu código original
 $dompdf->render();
 
 $filename = "reporte_inscripciones_evento_" . $eventoId . ".pdf";
 $dompdf->stream($filename, ["Attachment" => true]);
 exit;
+
+?>


### PR DESCRIPTION
Se modifico la paleta de colores y estilo de los 5 reportes que tiene el administrador para generar, los cuales son: reporte de certificados emitidos, reporte de inscripciones por evento, reporte del financiero, reporte de eventos y asistencia; y reporte de eventos por categoria.
Originalmente se tenia los reportes asi: 
![image](https://github.com/user-attachments/assets/c4ccd00f-8dbc-484a-9879-3f08ce3d2100)
Y ahora con los cambios, se ve asi: 
![image](https://github.com/user-attachments/assets/d77de512-d659-48be-9f27-bd8a0e8963b0)


De igual manera cada reporte tiene el mismo estilo y color: 
![image](https://github.com/user-attachments/assets/03c12b18-fdc9-4964-8b3b-f4755a9e263a)
![image](https://github.com/user-attachments/assets/79670f45-bd50-42ee-b54a-1b20753e8aed)
![image](https://github.com/user-attachments/assets/a4a0b22d-0cb5-4226-afda-2362b426c434)
